### PR TITLE
messages.yml: Fix typo leading to #3

### DIFF
--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -1,6 +1,6 @@
 messages:
   shopCategoriesTitle: "Shop - Categories"
-  transactionMissingResoucres: "You are missing the required resources for this transaction!"
+  transactionMissingResources: "You are missing the required resources for this transaction!"
   autosellTitle: "Autosell: "
   buyAmount: "Buy "
   prevLore: "Previous page"


### PR DESCRIPTION
Due to a typo in `messages.yml` the plugin couldn't find all required messages and replaced them with `null` in the Chat.

Fixes #3.