### PR TITLE
Improve user experience

### DIFF
--- a/src/main/java/io/github/nexadn/unitedshops/shop/ShopObject.java
+++ b/src/main/java/io/github/nexadn/unitedshops/shop/ShopObject.java
@@ -49,39 +49,25 @@ public class ShopObject implements PagerItem {
         for (int i = 0; i < 9; i++)
         {
             ItemStack it;
-            ItemMeta im;
-            List<String> il;
             switch (i) {
             case 0: // Kauf 1
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("buyAmount") + "1", "ev-b-1");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricebuy * 1);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("buyAmount") + "1",
+                        UnitedShops.plugin.getMessage("price") + this.pricebuy * 1);
                 it.setAmount(1);
                 this.buysellgui.setItem(i, it);
                 break;
             case 1: // Kauf 16
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("buyAmount") + "16", "ev-b-16");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricebuy * 16);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("buyAmount") + "16",
+                        UnitedShops.plugin.getMessage("price") + this.pricebuy * 16);
                 it.setAmount(16);
                 this.buysellgui.setItem(i, it);
                 break;
             case 2: // Kauf 64
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("buyAmount") + "64", "ev-b-64");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricebuy * 64);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("buyAmount") + "64",
+                        UnitedShops.plugin.getMessage("price") + this.pricebuy * 64);
                 it.setAmount(64);
                 this.buysellgui.setItem(i, it);
                 break;
@@ -89,8 +75,7 @@ public class ShopObject implements PagerItem {
                 this.buysellgui.setItem(i, GUIContainer.getBlank());
                 break;
             case 4: // Zurück
-                it = GUIContainer.getFunctionalItem(Material.BARRIER, UnitedShops.plugin.getMessage("back"),
-                        "ev-iback");
+                it = GUIContainer.getFunctionalItem(Material.BARRIER, UnitedShops.plugin.getMessage("back"));
                 it.setAmount(1);
                 this.buysellgui.setItem(i, it);
                 break;
@@ -99,34 +84,22 @@ public class ShopObject implements PagerItem {
                 break;
             case 6: // Verkauf 1
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("sellAmount") + "1", "ev-s-1");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricesell * 1);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("sellAmount") + "1",
+                        UnitedShops.plugin.getMessage("price") + this.pricesell * 1);
                 it.setAmount(1);
                 this.buysellgui.setItem(i, it);
                 break;
             case 7: // Verkauf 16
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("sellAmount") + "16", "ev-s-16");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricesell * 16);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("sellAmount") + "16",
+                        UnitedShops.plugin.getMessage("price") + this.pricesell * 16);
                 it.setAmount(16);
                 this.buysellgui.setItem(i, it);
                 break;
             case 8: // Verkauf 64
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("sellAmount") + "64", "ev-s-64");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricesell * 64);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("sellAmount") + "64",
+                        UnitedShops.plugin.getMessage("price") + this.pricesell * 64);
                 it.setAmount(64);
                 this.buysellgui.setItem(i, it);
             }

--- a/src/main/java/io/github/nexadn/unitedshops/shop/ShopObject.java
+++ b/src/main/java/io/github/nexadn/unitedshops/shop/ShopObject.java
@@ -54,34 +54,22 @@ public class ShopObject implements PagerItem {
             switch (i) {
             case 0: // Kauf 1
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("buyAmount") + "1", "ev-b-1");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricebuy * 1);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("buyAmount") + "1",
+                        UnitedShops.plugin.getMessage("price") + this.pricebuy * 1);
                 it.setAmount(1);
                 this.buysellgui.setItem(i, it);
                 break;
             case 1: // Kauf 16
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("buyAmount") + "16", "ev-b-16");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricebuy * 16);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("buyAmount") + "16",
+                        UnitedShops.plugin.getMessage("price") + this.pricebuy * 16);
                 it.setAmount(16);
                 this.buysellgui.setItem(i, it);
                 break;
             case 2: // Kauf 64
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("buyAmount") + "64", "ev-b-64");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricebuy * 64);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("buyAmount") + "64",
+                        UnitedShops.plugin.getMessage("price") + this.pricebuy * 64);
                 it.setAmount(64);
                 this.buysellgui.setItem(i, it);
                 break;
@@ -89,8 +77,7 @@ public class ShopObject implements PagerItem {
                 this.buysellgui.setItem(i, GUIContainer.getBlank());
                 break;
             case 4: // Zurück
-                it = GUIContainer.getFunctionalItem(Material.BARRIER, UnitedShops.plugin.getMessage("back"),
-                        "ev-iback");
+                it = GUIContainer.getFunctionalItem(Material.BARRIER, UnitedShops.plugin.getMessage("back"));
                 it.setAmount(1);
                 this.buysellgui.setItem(i, it);
                 break;
@@ -99,34 +86,22 @@ public class ShopObject implements PagerItem {
                 break;
             case 6: // Verkauf 1
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("sellAmount") + "1", "ev-s-1");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricesell * 1);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("sellAmount") + "1",
+                        UnitedShops.plugin.getMessage("price") + this.pricesell * 1);
                 it.setAmount(1);
                 this.buysellgui.setItem(i, it);
                 break;
             case 7: // Verkauf 16
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("sellAmount") + "16", "ev-s-16");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricesell * 16);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("sellAmount") + "16",
+                        UnitedShops.plugin.getMessage("price") + this.pricesell * 16);
                 it.setAmount(16);
                 this.buysellgui.setItem(i, it);
                 break;
             case 8: // Verkauf 64
                 it = GUIContainer.getFunctionalItem(this.itemstack.getType(),
-                        UnitedShops.plugin.getMessage("sellAmount") + "64", "ev-s-64");
-                im = it.getItemMeta();
-                il = im.getLore();
-                il.add(UnitedShops.plugin.getMessage("price") + this.pricesell * 64);
-                im.setLore(il);
-                it.setItemMeta(im);
+                        UnitedShops.plugin.getMessage("sellAmount") + "64",
+                        UnitedShops.plugin.getMessage("price") + this.pricesell * 64);
                 it.setAmount(64);
                 this.buysellgui.setItem(i, it);
             }

--- a/src/main/java/io/github/nexadn/unitedshops/shop/ShopObject.java
+++ b/src/main/java/io/github/nexadn/unitedshops/shop/ShopObject.java
@@ -1,13 +1,10 @@
 package io.github.nexadn.unitedshops.shop;
 
-import java.util.List;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.nexadn.unitedshops.UnitedShops;
 import io.github.nexadn.unitedshops.ui.PagerItem;

--- a/src/main/java/io/github/nexadn/unitedshops/tradeapi/MoneyTrade.java
+++ b/src/main/java/io/github/nexadn/unitedshops/tradeapi/MoneyTrade.java
@@ -29,7 +29,7 @@ public final class MoneyTrade {
             if (eReturn.transactionSuccess())
             {
                 player.getInventory().addItem(offer);
-                UnitedShops.plugin.sendMessage(player, "Trade: " + offer.toString() + " -> $" + want);
+                UnitedShops.plugin.sendMessage(player, UnitedShops.plugin.getMessage("tradePrefix") + offer.getType().toString() + " x" + offer.getAmount() + " -> $" + want);
                 return true;
             }
         }
@@ -55,7 +55,7 @@ public final class MoneyTrade {
                             ChatColor.RED + UnitedShops.plugin.getMessage("transactionFailed"));
                     return false;
                 }
-                UnitedShops.plugin.sendMessage(player, "Trade: $" + offer + " -> " + want.toString());
+                UnitedShops.plugin.sendMessage(player, "Trade: $" + offer + " -> " + want.getType().toString() + " x" + want.getAmount());
                 return true;
             }
         } else

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -13,6 +13,7 @@ messages:
   sellAmount: "Sell "
   price: "Price: "
   transactionFailed: "Transaction failed!"
+  tradePrefix: "Trade: "
   missingPermission: "You are missing the required permissions!"
   playerOnly: "You can only use that as a player!"
   


### PR DESCRIPTION
* Remove debugging item lores of items contained in trade UIs (“ev-b/s...”)
* Change formatting of successful trade chat output, removing “ItemStack{}” (using a better readable custom formatting instead) and using new `messages.yml` message `tradePrefix` as a prefix to the output of the trade information.

Closes #4.