### PR TITLE
WIP: Implement optional wildcard damage value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.project
 /.settings
 /dependency-reduced-pom.xml
+/.idea
+/unitedshops.iml

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.nexadn</groupId>
     <artifactId>unitedshops</artifactId>
-    <version>2.0.1</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>UnitedShops</name>
     <description>Bukkit/Spigot admin shop plugin</description>
     <url>https://github.com/NexAdn/UnitedShops</url>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         </repository>
         <repository>
             <id>vault-repo</id>
-            <url>https://nexus.hc.to/content/repositories/pub_releases/</url>
+            <url>http://nexus.hc.to/content/repositories/pub_releases/</url>
         </repository>
         <repository>
             <id>bstats-repo</id>

--- a/src/main/java/me/nexadn/unitedshops/objects/ItemType.java
+++ b/src/main/java/me/nexadn/unitedshops/objects/ItemType.java
@@ -1,0 +1,158 @@
+package me.nexadn.unitedshops.objects;
+
+import me.nexadn.unitedshops.Pair;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * A simple item type representation as used throughout UnitedShops
+ * <p>
+ * This class stores the basic information belonging to an item type.
+ * It can be used to generate {@link ItemStack} representations as well as check equality with and without wildcard
+ * support against the old {@link Pair} type as well as against other instances of this class.
+ */
+public class ItemType
+{
+    public Material material;
+    public short damage;
+
+    /**
+     * Create a new instance with the given material and a damage value of 0.
+     *
+     * @param material The material
+     * @throws IllegalArgumentException If the material is null
+     */
+    public ItemType(Material material)
+    {
+        this(material, (short) 0);
+    }
+
+    /**
+     * Create a new instance from the data contained in the item type {@link Pair}
+     *
+     * @param itemType The item type {@link Pair}
+     * @throws IllegalArgumentException If the material is null
+     */
+    public ItemType(Pair<Material, Short> itemType)
+    {
+        this(itemType.first, itemType.second);
+    }
+
+    /**
+     * Create a new instance with the given material and damage value.
+     *
+     * @param material The material
+     * @param damage   The damage value. If negative, this instance becomes an item type with wildcard damage value.
+     *                 Representations as returned by {@link #getAsItemStack()} will have a damage of 0. A call to
+     *                 {@link #matches(ItemType)} or {@link #matches(Pair)} will skip the check for equality of
+     *                 damage values.
+     */
+    public ItemType(Material material, short damage)
+    {
+        if (material == null) {
+            throw new IllegalArgumentException("Material cannot be null.");
+        }
+        this.material = material;
+        this.damage = damage;
+    }
+
+    /**
+     * Creates an {@link ItemStack} using this instance's item type data.
+     *
+     * @return The created {@link ItemStack} with one item.
+     */
+    public ItemStack getAsItemStack()
+    {
+        return this.getAsItemStack(1);
+    }
+
+    /**
+     * Creates an {@link ItemStack} using this instance's item type data.
+     *
+     * @param amount The amount of items of the returned {@link ItemStack}
+     * @return The created {@link ItemStack} with the given amount of items.
+     */
+    public ItemStack getAsItemStack(int amount)
+    {
+        if (amount < 1) {
+            throw new IllegalArgumentException("Amount must be positive.");
+        }
+
+        return new ItemStack(this.material, amount, this.isAnyDamage() ? 0 : this.damage);
+    }
+
+    /**
+     * Creates an item type {@link Pair} using this instance's item type data.
+     *
+     * @return The created {@link Pair}.
+     */
+    public Pair<Material, Short> getAsItemTypePair()
+    {
+        return new Pair<>(this.material, this.damage);
+    }
+
+    /**
+     * Returns, whether or not this instance has a wildcard damage value
+     *
+     * @return true, if it has a wildcard damage value; false otherwise
+     */
+    public boolean isAnyDamage()
+    {
+        return this.damage < 0;
+    }
+
+    /**
+     * Creates an {@link ItemType} from the given {@link Pair} and calls {@link #matches(ItemType)}
+     *
+     * @param itemType The {@link Pair}
+     */
+    public boolean matches(Pair<Material, Short> itemType)
+    {
+        return this.matches(new ItemType(itemType.first, itemType.second));
+    }
+
+    /**
+     * Checks against equality under consideration of a possibly present wildcard damage value.
+     * <p>
+     * If either one of the two {@link ItemType} instances (this or the parameter) contain a wildcard damage (if
+     * {@link #isAnyDamage()} returns true for one of these), only the materials are checked for equality, otherwise
+     * the damage values are checked for equality, too.
+     *
+     * @param itemType The right-hand-side {@link ItemType}
+     * @return true, if the item types match under consideration of possible wildcard values; false, otherwise
+     */
+    public boolean matches(ItemType itemType)
+    {
+        return (this.material.equals(itemType.material)) && ((this.isAnyDamage() || itemType.isAnyDamage()) ? true :
+                (this.damage == itemType.damage));
+    }
+
+    /**
+     * Overridden and adjusted equals-method from {@link Object} for checking value equality of item type
+     * {@link Pair}s and other {@link ItemType}s.
+     * <p>
+     * This method checks against equality without consideration of a possibliy presend wildcard damage value, if the
+     * right hand side object is either a {@link Pair} or an {@link ItemType}.
+     * This means, that both material and damage are checked against equality regardless of the presence of wildcard
+     * values in either one of the two objects.
+     * <p>
+     * If the right hand side object is neither an instance of {@link Pair} nor of {@link ItemType}, the standard
+     * {@link Object#equals(Object)} is used.
+     *
+     * @param rhs The right hand side object to be checked against.
+     * @return true, if the criteria for equality are fulfilled (see method description); false otherwise
+     */
+    @Override
+    public boolean equals(Object rhs)
+    {
+        if (rhs instanceof Pair) {
+            Pair p = (Pair) rhs;
+            return (this.material.equals(p.first) && p.second.equals(this.damage));
+        } else if (rhs instanceof ItemType) {
+            ItemType it = (ItemType) rhs;
+            return (it.material.equals(this.material) && it.damage == this.damage);
+        } else {
+            return super.equals(rhs);
+        }
+    }
+}

--- a/src/test/java/me/nexadn/unitedshops/objects/ItemTypeTest.java
+++ b/src/test/java/me/nexadn/unitedshops/objects/ItemTypeTest.java
@@ -1,0 +1,141 @@
+package me.nexadn.unitedshops.objects;
+
+import me.nexadn.unitedshops.Pair;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ItemTypeTest
+{
+    @Test
+    public void testSaneCreationMaterialOnly()
+    {
+        ItemType itemType = new ItemType(Material.COBBLESTONE);
+    }
+
+    @Test
+    public void testCorruptedCreationMaterialOnly()
+    {
+        try {
+            Material m = null;
+            ItemType itemType = new ItemType(m);
+            fail("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // Success
+        }
+    }
+
+    @Test
+    public void testSaneCreationMaterialAndDamage()
+    {
+        ItemType itemType = new ItemType(Material.COBBLESTONE, (short) 1);
+    }
+
+    @Test
+    public void testCorruptedCreationMaterialAndDamage()
+    {
+        try {
+            ItemType itemType = new ItemType(null, (short) 5);
+            fail("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // Success
+        }
+    }
+
+    @Test
+    public void testSaneCreationItemTypePair()
+    {
+        ItemType itemType = new ItemType(new Pair<>(Material.COBBLE_WALL, (short) 1));
+    }
+
+    @Test
+    public void testCorruptedCreationItemTypePair()
+    {
+        try {
+            ItemType itemType = new ItemType(new Pair<>(null, (short) 1));
+            fail("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // Success
+        }
+    }
+
+    @Test
+    public void testGetAsItemStack()
+    {
+        ItemType it = new ItemType(Material.COBBLESTONE, (short) 0);
+        ItemStack is = it.getAsItemStack(32);
+        assertEquals(32, is.getAmount());
+        assertEquals(0, is.getDurability());
+        assertEquals(Material.COBBLESTONE, is.getType());
+
+        it = new ItemType(Material.COBBLESTONE, (short) -1);
+        is = it.getAsItemStack();
+        assertEquals(1, is.getAmount());
+        assertEquals(0, is.getDurability());
+        assertEquals(Material.COBBLESTONE, is.getType());
+
+        try {
+            it = new ItemType(Material.COBBLESTONE, (short) -1);
+            is = it.getAsItemStack(0);
+            fail("Missing IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // Success
+        }
+    }
+
+    @Test
+    public void testGetAsPair()
+    {
+        ItemType it = new ItemType(Material.COBBLESTONE, (short) 0);
+        Pair<Material, Short> itp = it.getAsItemTypePair();
+        assertEquals(it.material, itp.first);
+        assertEquals(it.damage, itp.second.shortValue());
+    }
+
+    @Test
+    public void testIsAnyDamage()
+    {
+        ItemType it1 = new ItemType(Material.COBBLESTONE, (short) 0);
+        ItemType it2 = new ItemType(Material.COBBLESTONE, (short) -1);
+        assertFalse(it1.isAnyDamage());
+        assertTrue(it2.isAnyDamage());
+    }
+
+    @Test
+    public void testMatches()
+    {
+        ItemType lhs = new ItemType(Material.COBBLESTONE, (short) 0);
+        ItemType rhs1 = new ItemType(Material.COBBLESTONE, (short) 1);
+        ItemType rhs2 = new ItemType(Material.COBBLESTONE, (short) -1);
+        Pair<Material, Short> rhs3 = new Pair<>(Material.COBBLE_WALL, (short) 0);
+        Pair<Material, Short> rhs4 = new Pair<>(Material.COBBLE_WALL, (short) -1);
+
+        assertTrue(lhs.matches(lhs));
+        assertFalse(lhs.matches(rhs1));
+        assertTrue(lhs.matches(rhs2));
+        assertFalse(lhs.matches(rhs3));
+        assertFalse(lhs.matches(rhs4));
+    }
+
+    @Test
+    public void testEquals()
+    {
+        ItemType lhs = new ItemType(Material.COBBLESTONE, (short) 0);
+        ItemType rhs1 = new ItemType(Material.COBBLESTONE, (short) 1);
+        ItemType rhs2 = new ItemType(Material.COBBLESTONE, (short) -1);
+        Pair<Material, Short> rhs3 = new Pair<>(Material.COBBLE_WALL, (short) 0);
+        Pair<Material, Short> rhs4 = new Pair<>(Material.COBBLE_WALL, (short) -1);
+        ItemType rhs5 = new ItemType(Material.COBBLESTONE, (short) 0);
+        Pair<Material, Short> rhs6 = new Pair<>(Material.COBBLESTONE, (short) 0);
+
+        assertTrue(lhs.equals(lhs));
+        assertFalse(lhs.equals(rhs1));
+        assertFalse(lhs.equals(rhs2));
+        assertFalse(lhs.equals(rhs3));
+        assertFalse(lhs.equals(rhs4));
+        assertTrue(lhs.equals(rhs5));
+        assertTrue(lhs.equals(rhs6));
+    }
+}


### PR DESCRIPTION
This pull request adds the possibility to use a wildcard damage value for selling items. For buying and for representation as item, the damage value '0' will be assumed.

This PR is still WIP.

Closes #24.
Probably closes #39.